### PR TITLE
Fly / Dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.dockerignore
+Procfile*
+config/master.key
+config/credentials.yml.enc
+.byebug_history
+log/*
+tmp/*
+public/packs
+public/packs-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,73 @@
+# Arcane secrets of Rails Dockermancy gleaned from:
+# - https://docs.docker.com/samples/rails/
+# - https://evilmartians.com/chronicles/ruby-on-whales-docker-for-ruby-rails-development
+# - https://community.fly.io/t/ruby-on-rails-deployments/341/18
+
+ARG RUBY_VERSION
+FROM ruby:${RUBY_VERSION}-slim-buster
+
+# Common dependencies
+RUN apt-get update -qq \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    build-essential \
+    gnupg2 \
+    curl \
+    less \
+    git \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/* \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && truncate -s 0 /var/log/*log
+
+ARG PG_VERSION
+ARG NODE_VERSION
+
+# Add PostgreSQL to sources list
+RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main $PG_VERSION" > /etc/apt/sources.list.d/pgdg.list
+
+# Add NodeJS to sources list
+RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
+
+# Add Yarn to the sources list
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
+
+# Install dependencies
+RUN apt-get update -qq \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    libpq-dev \
+    postgresql-client-$PG_VERSION \
+    nodejs \
+    yarn \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/* \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && truncate -s 0 /var/log/*log
+
+ARG BUNDLER_VERSION
+
+# Upgrade RubyGems and install required Bundler version
+RUN gem update --system && \
+    gem install bundler:$BUNDLER_VERSION
+
+RUN mkdir -p /rails
+WORKDIR /rails
+
+ARG RAILS_ENV="production"
+ENV RAILS_ENV=${RAILS_ENV}
+ARG BUNDLE_WITHOUT="development test"
+ENV BUNDLE_WITHOUT=${BUNDLE_WITHOUT}
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle config --global frozen 1 \
+    && bundle install -j4 --retry 3 \
+    && rm -rf /usr/local/bundle/cache/*.gem \
+    && find /usr/local/bundle/gems/ -name "*.c" -delete \
+    && find /usr/local/bundle/gems/ -name "*.o" -delete
+
+COPY . .
+
+RUN bundle exec /rails/bin/webpack
+
+CMD rails s -p 3000 -b 0.0.0.0

--- a/bin/docker-compose-entrypoint
+++ b/bin/docker-compose-entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ -f /app/tmp/pids/server.pid ]; then
+  rm /app/tmp/pids/server.pid
+fi
+
+bundle exec rake db:migrate
+
+bundle exec rake webpacker:compile
+
+exec bundle exec "$@"

--- a/bin/fly-deploy
+++ b/bin/fly-deploy
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+bundle exec rake db:prepare

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module StimulusreflexCom
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.hosts << ENV.fetch("APP_HOST", "0.0.0.0")
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,5 +8,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= "redis://#{ENV['FLY_REGION']}.#{ENV['REDIS_HOST']}/1" %>
   channel_prefix: stimulusreflex_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,4 +17,4 @@ test:
 
 production:
   <<: *default
-  database: stimulusreflexcom_production
+  url: <%= ENV["DATABASE_URL"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,10 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: <%= ENV.fetch("DB_HOST", nil) %>
+  port: <%= ENV.fetch("DB_PORT", 5432) %>
+  username: <%= ENV.fetch("DB_USER", nil) %>
+  password: <%= ENV.fetch("DB_PASSWORD", nil) %>
 
 development:
   <<: *default
@@ -14,5 +18,3 @@ test:
 production:
   <<: *default
   database: stimulusreflexcom_production
-  username: stimulusreflexcom
-  password: <%= ENV['STIMULUSREFLEX_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -124,4 +124,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.action_controller.default_url_options = { host: ENV["APP_HOST"] }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,11 +23,13 @@ Rails.application.configure do
       expire_after: 1.year,
       ttl: 1.year,
       key_prefix: "stimulusreflex:session:",
-      url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }
+      url: "redis://#{ENV['FLY_REGION']}.#{ENV['REDIS_HOST']}/1"
     }
   }
 
-  config.cache_store = :redis_cache_store, {url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }}
+  config.cache_store = :redis_cache_store, {
+    url: "redis://#{ENV['FLY_REGION']}.#{ENV['REDIS_HOST']}/1"
+  }
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).

--- a/config/redis/shared.yml
+++ b/config/redis/shared.yml
@@ -1,5 +1,5 @@
 production: &production
-  url: <%= ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/1") %>
+  url: <%= "redis://#{ENV['FLY_REGION']}.#{ENV['REDIS_HOST']}/1" %>
   timeout: 1
 
 development: &development

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -2,11 +2,14 @@ var path = require('path')
 process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
-environment.config.devServer.watchContentBase = false
-environment.config.devServer.contentBase = [
-  path.join(__dirname, '../../app/views'),
-  path.join(__dirname, '../../app/helpers'),
-  path.join(__dirname, '../../app/reflexes')
-]
+
+if(environment.config.devServer) {
+  environment.config.devServer.watchContentBase = false
+  environment.config.devServer.contentBase = [
+    path.join(__dirname, '../../app/views'),
+    path.join(__dirname, '../../app/helpers'),
+    path.join(__dirname, '../../app/reflexes')
+  ]
+}
 
 module.exports = environment.toWebpackConfig()

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+# docker-compose isn't used by Fly, but can be used for doing quick dev checks of the Dockerfile setup
+
+version: "3"
+services:
+  app:
+    build:
+      context: .
+      args:
+        RAILS_ENV: development
+        BUNDLE_WITHOUT: test
+        RUBY_VERSION: 2.7.3
+        PG_VERSION: 12
+        NODE_VERSION: 14
+        BUNDLER_VERSION: 2.2.19
+    entrypoint: ["/rails/bin/docker-compose-entrypoint"]
+    command: "rails s -p 3000 -b 0.0.0.0"
+    volumes:
+      - .:/rails:cached
+      - rails_cache:/rails/tmp/cache
+      - packs:/rails/public/packs
+    environment:
+      RAILS_ENV: development
+      REDIS_URL: redis://redis:6379/
+      DB_HOST: postgres
+      DB_USER: stimulusreflexcom
+      DB_PASSWORD: stimulusreflexcom
+      BOOTSNAP_CACHE_DIR: /usr/local/bundle/_bootsnap
+    ports:
+      - "3000:3000"
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:12
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: stimulusreflexcom_development
+      POSTGRES_USER: stimulusreflexcom
+      POSTGRES_PASSWORD: stimulusreflexcom
+    ports:
+      - "5432"
+    healthcheck:
+      test: pg_isready -U stimulusreflexcom -d stimulusreflexcom_development -h 127.0.0.1
+      interval: 5s
+
+  redis:
+    image: redis:6.2.5-alpine
+    volumes:
+      - redis:/data
+    ports:
+      - "6379"
+    healthcheck:
+      test: redis-cli ping
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
+volumes:
+  postgres:
+  redis:
+  rails_cache:
+  packs:

--- a/fly.toml
+++ b/fly.toml
@@ -21,6 +21,10 @@ processes = []
 [deploy]
   release_command = "sh /rails/bin/fly-deploy"
 
+[[statics]]
+  guest_path = "/rails/public/packs"
+  url_prefix = "/packs"
+
 [experimental]
   allowed_public_ports = []
   auto_rollback = true

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,39 @@
+# fly.toml file generated for stimulusreflexdotcom on 2022-01-01T15:40:47Z
+
+app = "stimulusreflexdotcom"
+
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,19 @@ kill_timeout = 5
 processes = []
 
 [env]
+  RAILS_ENV = "production"
+  PRIMARY_REGION = "lax"
+  RAILS_LOG_TO_STDOUT = true
+
+[build]
+  [build.args]
+    RUBY_VERSION = "2.7.3"
+    PG_VERSION = "12"
+    NODE_VERSION = "14"
+    BUNDLER_VERSION = "2.2.19"
+
+[deploy]
+  release_command = "sh /rails/bin/fly-deploy"
 
 [experimental]
   allowed_public_ports = []
@@ -14,7 +27,7 @@ processes = []
 
 [[services]]
   http_checks = []
-  internal_port = 8080
+  internal_port = 3000
   processes = ["app"]
   protocol = "tcp"
   script_checks = []


### PR DESCRIPTION
Draft version of Dockerizing / Flyifying the app for deployment on `fly.io`

Uses this fly-app for Redis: https://github.com/Matt-Yorkley/fly-redis/commits/sr-dotcom

I'll write some notes up soon, but there were a few things which I skipped over quickly that might want some more thought:
- Docker vs Buildpacks options for deploying; I went with Docker
- Secrets management; Fly has it's own system
- The database setup is a bit weird as the app requires one but doesn't currently *use* it for anything